### PR TITLE
Provide a command input for number of iterations, update gateway

### DIFF
--- a/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeDoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeDoctrineDatabase.php
@@ -85,5 +85,10 @@ class PageFieldTypeDoctrineDatabase implements PageFieldTypeGatewayInterface
                 $this->pageFieldTypeGateway->removeZone((int) $attribute['zone_id']);
             }
         }
+
+        foreach ($this->pageFieldTypeGateway->loadZonesAssignedToPage($pageId) as $zone) {
+            $this->pageFieldTypeGateway->unassignZoneFromPage((int) $zone['id'], $pageId);
+            $this->pageFieldTypeGateway->removeZone((int) $zone['id']);
+        }
     }
 }


### PR DESCRIPTION
The question about the number of iterations in `ezplatform:page-fieldtype-cleanup` command has been provided for the user to input.

Besides, a minor update to the `removePage` gateway command which handles the removal of related page items if there are no blocks for the orphaned pages that exist.


