### PR TITLE
Extend 'page-fieldtype-cleanup' command to remove leftovers

### DIFF
--- a/src/bundle/Command/PageFieldTypeCleanupCommand.php
+++ b/src/bundle/Command/PageFieldTypeCleanupCommand.php
@@ -96,33 +96,29 @@ EOT
 
         $limit = (int) $helper->ask($input, $output, $question);
 
-        $count = $this->countOrphanedPageRelations();
-
-        if ($count) {
-            $this->deleteOrphanedPageRelations($limit);
-        }
+        $this->countOrphanedPageRelations();
+        $this->deleteOrphanedPageRelations($limit);
 
         $this->io->success('Done');
 
         return 0;
     }
 
-    private function countOrphanedPageRelations(): int
+    private function countOrphanedPageRelations(): void
     {
         $count = $this->gateway->countOrphanedPageRelations();
 
         $count <= 0
             ? $this->io->success('Found: 0')
             : $this->io->caution(sprintf('Found: %d orphaned pages', $count));
-
-        return $count;
     }
 
     private function deleteOrphanedPageRelations(int $limit): void
     {
         if (!$this->io->confirm(
             sprintf('Are you sure that you want to proceed? The maximum number of pages that will be cleaned
-             in this iteration is equal to %d.', $limit),
+             in this iteration is equal to %d. If the number is equal to 0 you can still continue to run the remaining
+             cleaning methods.', $limit),
             false)
         ) {
             return;

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -26,6 +26,7 @@ services:
     MateuszBieniek\EzPlatformDatabaseHealthCheckerBundle\Command\PageFieldTypeCleanupCommand:
         arguments:
             $gateway: '@MateuszBieniek\EzPlatformDatabaseHealthChecker\Persistence\Legacy\Content\Gateway\PageFieldTypeDoctrineDatabase'
+            $repository: '@ezpublish.api.repository'
         tags:
             - { name: 'console.command', command: 'ezplatform:page-fieldtype-cleanup' }
 

--- a/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeDoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeDoctrineDatabase.php
@@ -91,4 +91,124 @@ class PageFieldTypeDoctrineDatabase implements PageFieldTypeGatewayInterface
             $this->pageFieldTypeGateway->removeZone((int) $zone['id']);
         }
     }
+
+    public function getOrphanedBlockIds(int $limit): array
+    {
+        $zonesQuery = $this->connection->createQueryBuilder();
+        $zonesQuery = $zonesQuery->select('id')
+            ->from('ezpage_zones')
+            ->getSQL();
+
+        $orphanedBlocksQuery = $this->connection->createQueryBuilder();
+        $orphanedBlocksQuery->select('block_id')
+            ->from('ezpage_map_blocks_zones', 'bz')
+            ->where(
+                $orphanedBlocksQuery->expr()->notIn(
+                    'zone_id',
+                    $zonesQuery
+                )
+            )
+            ->setMaxResults($limit);
+
+        return $orphanedBlocksQuery->execute()->fetchAll(FetchMode::COLUMN);
+    }
+
+    public function getOrphanedAttributeIds(array $blockIds): array
+    {
+        $orphanedAttributesQuery = $this->connection->createQueryBuilder();
+        $orphanedAttributesQuery->select('attribute_id')
+            ->from('ezpage_map_attributes_blocks')
+            ->where(
+                $orphanedAttributesQuery->expr()->in(
+                    'block_id',
+                    $orphanedAttributesQuery->createPositionalParameter($blockIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+
+        return $orphanedAttributesQuery->execute()->fetchAll(FetchMode::COLUMN);
+    }
+
+    public function removeOrphanedBlockAttributes(array $attributeIds): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->delete('ezpage_map_attributes_blocks')
+            ->where(
+                $query->expr()->in(
+                    'attribute_id',
+                    $query->createPositionalParameter($attributeIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+
+        $query->execute();
+    }
+
+    public function removeOrphanedAttributes(array $attributeIds): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->delete('ezpage_attributes')
+            ->where(
+                $query->expr()->in(
+                    'id',
+                    $query->createPositionalParameter($attributeIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+
+        $query->execute();
+    }
+
+    public function removeOrphanedBlockDesigns(array $blockIds): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->delete('ezpage_blocks_design')
+            ->where(
+                $query->expr()->in(
+                    'block_id',
+                    $query->createPositionalParameter($blockIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+
+        $query->execute();
+    }
+
+    public function removeOrphanedBlockVisibilities(array $blockIds): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->delete('ezpage_blocks_visibility')
+            ->where(
+                $query->expr()->in(
+                    'block_id',
+                    $query->createPositionalParameter($blockIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+
+        $query->execute();
+    }
+
+    public function removeOrphanedBlocksZones(array $blockIds): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->delete('ezpage_map_blocks_zones')
+            ->where(
+                $query->expr()->in(
+                    'block_id',
+                    $query->createPositionalParameter($blockIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+
+        $query->execute();
+    }
+
+    public function removeOrphanedBlocks(array $blockIds): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->delete('ezpage_blocks')
+            ->where(
+                $query->expr()->in(
+                    'id',
+                    $query->createPositionalParameter($blockIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+
+        $query->execute();
+    }
 }

--- a/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeGatewayInterface.php
+++ b/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeGatewayInterface.php
@@ -9,4 +9,20 @@ interface PageFieldTypeGatewayInterface
     public function countOrphanedPageRelations(): int;
 
     public function getOrphanedPageRelations(int $limit): array;
+
+    public function getOrphanedBlockIds(int $limit): array;
+
+    public function getOrphanedAttributeIds(array $blockIds): array;
+
+    public function removeOrphanedBlockAttributes(array $attributeIds): void;
+
+    public function removeOrphanedAttributes(array $attributeIds): void;
+
+    public function removeOrphanedBlockDesigns(array $blockIds): void;
+
+    public function removeOrphanedBlockVisibilities(array $blockIds): void;
+
+    public function removeOrphanedBlocksZones(array $blockIds): void;
+
+    public function removeOrphanedBlocks(array $blockIds): void;
 }

--- a/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeGatewayInterface.php
+++ b/src/lib/Persistence/Legacy/Content/Gateway/PageFieldTypeGatewayInterface.php
@@ -10,19 +10,44 @@ interface PageFieldTypeGatewayInterface
 
     public function getOrphanedPageRelations(int $limit): array;
 
+    /**
+     * @return int[]
+     */
     public function getOrphanedBlockIds(int $limit): array;
 
+    /**
+     * @param int[] $blockIds
+     * @return int[]
+     */
     public function getOrphanedAttributeIds(array $blockIds): array;
 
+    /**
+     * @param int[] $attributeIds
+     */
     public function removeOrphanedBlockAttributes(array $attributeIds): void;
 
+    /**
+     * @param int[] $attributeIds
+     */
     public function removeOrphanedAttributes(array $attributeIds): void;
 
+    /**
+     * @param int[] $blockIds
+     */
     public function removeOrphanedBlockDesigns(array $blockIds): void;
 
+    /**
+     * @param int[] $blockIds
+     */
     public function removeOrphanedBlockVisibilities(array $blockIds): void;
 
+    /**
+     * @param int[] $blockIds
+     */
     public function removeOrphanedBlocksZones(array $blockIds): void;
 
+    /**
+     * @param int[] $blockIds
+     */
     public function removeOrphanedBlocks(array $blockIds): void;
 }


### PR DESCRIPTION
The `ezplatform:page-fieldtype-cleanup` has been extended to remove `ezpage_*` records which could not be deleted by the standard `removePage` gateway method that resulted from [EZEE-3430](https://issues.ibexa.co/browse/EZEE-3430).

Those leftovers may be present because of direct queries run on the database which broke the relations in `removePage` method.

![image](https://user-images.githubusercontent.com/22300504/149148311-d516bc94-969a-42bd-872a-ed1350d6dcda.png)
